### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "clang++-7 -pthread -std=c++11 -o main main.cpp && ./main"

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Winning and Losing:
 If the blocks reach the top, you lose!
 There is no Winning, so play until you lose.
 
-(This is a prototype from https://www.repl.it)
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/Tetris_With_Sticks)](https://repl.it/github/UzayAnil/Tetris_With_Sticks)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/TetrisWithSticks-1).